### PR TITLE
Add SetYearProgress method to PersianDateTime class

### DIFF
--- a/src/Persia.Net.Test/PersianDateTimeTests.cs
+++ b/src/Persia.Net.Test/PersianDateTimeTests.cs
@@ -133,5 +133,31 @@ namespace Persia.Net.Test
             Assert.Equal(new DateOnly(2024, 03, 20), dateOnly);
         }
 
+        [Fact]
+        public void Test_IsGivenPersianYearIsLeap_ReturnCorrectDate()
+        {
+            // Arrange
+            const int persianYear = 1403;
+
+            // Act
+            var leapStatus = PersianDateTime.CheckLeapYear(persianYear);
+
+            // Assert
+            Assert.Equal(false, leapStatus);
+        }
+
+        [Fact]
+        public void Test_GetDayOfYearAndDaysRamainingInYear_ReturnCorrectNumbers()
+        {
+            // Arrange
+            var date = new DateTime(2024, 03, 19);
+
+            // Act
+            var persianDate = date.ToPersianDateTime();
+
+            // Assert
+            Assert.Equal(365, persianDate.DayOfYear);
+            Assert.Equal(0, persianDate.DaysRemainingInYear);
+        }
     }
 }

--- a/src/Persia.Net/Constants/CalendarConstants.cs
+++ b/src/Persia.Net/Constants/CalendarConstants.cs
@@ -205,4 +205,19 @@ internal class CalendarConstants
     /// The offset used in the calculation of the month from a Julian day number.
     /// </summary>
     internal const int MonthCalculationOffset = 373;
+
+    /// <summary>
+    /// The length of a complete grand cycle in the Persian calendar, consisting of 2820 years.
+    /// </summary>
+    internal const int PersianCalendarGrandCycle = 2820;
+
+    /// <summary>
+    /// The number of years in the smaller cycles within the 2820-year grand cycle of the Persian calendar.
+    /// </summary>
+    internal const int YearsInSmallCycle = 120;
+
+    /// <summary>
+    /// The index of the last year in the smaller 120-year cycle of the Persian calendar.
+    /// </summary>
+    internal const int LastYearInSmallCycleIndex = 119;
 }

--- a/src/Persia.Net/DateTimes/Converter.cs
+++ b/src/Persia.Net/DateTimes/Converter.cs
@@ -11,9 +11,17 @@ internal static class Converter
     /// <returns>A PersianDateTime object representing the converted Persian date.</returns>
     internal static PersianDateTime ConvertToPersian(DateTime date)
     {
+        // Convert the Gregorian date to Julian Day Number
         var jd = GregorianTojulianDay(date.Year, date.Month, date.Day);
-        var dateOnly = JulianDayToPersian(jd);
-        return new PersianDateTime(dateOnly.Year, dateOnly.Month, dateOnly.Day);
+
+        // Convert the Julian Day Number to a Persian date
+        var persianDate = JulianDayToPersian(jd);
+
+        // Get the progress of the year for the Persian date
+        var (dayOfYear, daysRemainingInYear) = GetYearProgress(persianDate.Year, date);
+
+        persianDate.SetYearProgress(dayOfYear, daysRemainingInYear);
+        return persianDate;
     }
 
     internal static DateTime ConvertToGregorian(int year, int month, int day, int hour, int minute, int second, int millisecond = 0)
@@ -46,7 +54,7 @@ internal static class Converter
     /// </summary>
     /// <param name="julianDay">The Julian Day number to be converted.</param>
     /// <returns>A PersianDateOnly object representing the converted Persian date.</returns>
-    private static PersianDateOnly JulianDayToPersian(double julianDay)
+    private static PersianDateTime JulianDayToPersian(double julianDay)
     {
         julianDay = Math.Floor(julianDay) + 0.5;
 
@@ -65,7 +73,7 @@ internal static class Converter
         var month = dayOfYear <= DaysInHalfYear ? (int)Math.Ceiling(dayOfYear / 31) : (int)Math.Ceiling((dayOfYear - 6) / 30);
         var day = (int)(julianDay - PersianToJulianDay(year, month, 1)) + 1;
 
-        return new PersianDateOnly(year, month, day);
+        return new PersianDateTime(year, month, day);
     }
 
     /// <summary>
@@ -154,4 +162,26 @@ internal static class Converter
 
         return (year, month, day);
     }
+
+    /// <summary>
+    /// Calculates the progress of the year in the Persian calendar for a given date.
+    /// </summary>
+    /// <param name="year">The year in the Persian calendar.</param>
+    /// <param name="date">The date for which to calculate the year progress.</param>
+    /// <returns>A tuple containing the day of the year and the number of days remaining in the year.</returns>
+    public static (int DayOfYear, int DaysRemainingInYear) GetYearProgress(int year, DateTime date)
+    {
+        // Calculate the JDN (Julian Day Number) for the start and end of the year
+        var jdnStartOfYear = PersianToJulianDay(year, 1, 1);
+        var jdnEndOfYear = PersianToJulianDay(year + 1, 1, 1) - 1;
+
+        // Calculate the JDN for the given date
+        var jdn = GregorianTojulianDay(date.Year, date.Month, date.Day);
+
+        var DayOfYear = (int)(jdn - jdnStartOfYear + 1);
+        var DaysRemainingInYear = (int)(jdnEndOfYear - jdn);
+
+        return (DayOfYear, DaysRemainingInYear);
+    }
+
 }

--- a/src/Persia.Net/DateTimes/DateTimeExtensions.cs
+++ b/src/Persia.Net/DateTimes/DateTimeExtensions.cs
@@ -14,7 +14,8 @@ public static class DateTimeExtensions
 
         return Converter.ConvertToPersian(date.Value)
             .SetTime(TimeOnly.FromTimeSpan(date.Value.TimeOfDay))
-            .SetDayOfWeek((int)date.Value.DayOfWeek);
+            .SetDayOfWeek((int)date.Value.DayOfWeek)
+            .GetLeapYearStatus();
     }
 
     /// <summary>
@@ -26,7 +27,7 @@ public static class DateTimeExtensions
     {
         return Converter.ConvertToPersian(date)
             .SetTime(TimeOnly.FromTimeSpan(date.TimeOfDay))
-            .SetDayOfWeek((int)date.DayOfWeek);
+            .SetDayOfWeek((int)date.DayOfWeek)
+            .GetLeapYearStatus();
     }
-
 }


### PR DESCRIPTION
Description:
This pull request adds a new method, SetYearProgress, to the PersianDateTime class. The SetYearProgress method calculates the DayOfYear and DaysRemainingInYear for a given date in the Persian calendar.

Changes:
- Add SetYearProgress method to PersianDateTime class
- Update ConvertToPersian method to use SetYearProgress

This enhancement improves the functionality of the PersianDateTime class by providing a way to calculate and set the progress of the year for a given date.