### PR TITLE
Update Persian calendar tests and refactor conversion logic

### DIFF
--- a/src/Persia.Net.Test/PersianDateOnlyTests.cs
+++ b/src/Persia.Net.Test/PersianDateOnlyTests.cs
@@ -3,15 +3,20 @@
 public class PersianDateOnlyTests
 {
     [Theory]
-    [InlineData(2025, 03, 21, 1, 1, 1404)]
-    [InlineData(2025, 03, 20, 30, 12, 1403)]
-    [InlineData(2025, 03, 19, 29, 12, 1403)]
     [InlineData(1977, 02, 08, 19, 11, 1355)]
+    [InlineData(1980, 07, 20, 29, 4, 1359)]
+    [InlineData(1995, 12, 31, 10, 10, 1374)]
     [InlineData(2000, 01, 01, 11, 10, 1378)]
     [InlineData(2010, 05, 15, 25, 2, 1389)]
-    [InlineData(1995, 12, 31, 10, 10, 1374)]
-    [InlineData(1980, 07, 20, 29, 4, 1359)]
     [InlineData(2022, 09, 23, 1, 7, 1401)]
+    [InlineData(2025, 03, 19, 29, 12, 1403)]
+    [InlineData(2025, 03, 20, 30, 12, 1403)]
+    [InlineData(2025, 03, 21, 1, 1, 1404)]
+    [InlineData(2028, 03, 20, 1, 1, 1407)] // New entry
+    [InlineData(2029, 03, 19, 29, 12, 1407)] // New entry
+    [InlineData(2029, 03, 20, 1, 1, 1408)] // New entry
+    [InlineData(2030, 03, 20, 30, 12, 1408)] // New entry
+    [InlineData(2034, 03, 20, 30, 12, 1412)] // New entry
     public void Test_ConvertToPersianDate_ReturnCorrectDate(int year, int month, int day, int expectedDay, int expectedMonth, int expectedYear)
     {
         // Arrange
@@ -32,3 +37,4 @@ public class PersianDateOnlyTests
         Assert.Equal(expectedYear, convertedNonNullableDate.Year);
     }
 }
+

--- a/src/Persia.Net.Test/PersianDateTimeTests.cs
+++ b/src/Persia.Net.Test/PersianDateTimeTests.cs
@@ -114,23 +114,46 @@ public class PersianDateTimeTests
         Assert.Equal("جمعه ۳ فروردین ۱۴۰۳", convertedDateString);
     }
 
-    [Fact]
-    public void Test_ConvertToDateTime_ReturnCorrectDate()
+    //[Fact]
+    //public void Test_ConvertToDateTime_ReturnCorrectDate()
+    //{
+    //    // Arrange
+    //    const int persianYear = 1355;
+    //    const int persianMonth = 11;
+    //    const int persianDay = 19;
+
+    //    // Act
+    //    var date = PersianDateTime.ToDateTime(persianYear, persianMonth, persianDay).Date;
+    //    var dateOnly = PersianDateTime.ToDateOnly(persianYear, persianMonth, persianDay);
+
+    //    // Assert
+    //    Assert.Equal(new DateTime(2025, 03, 26).Date, date);
+    //    Assert.Equal(new DateOnly(2025, 03, 26), dateOnly);
+    //}
+
+    [Theory]
+    [InlineData(1355, 11, 19, 08, 02, 1977)]
+    [InlineData(1404, 1, 1, 21, 03, 2025)]
+    [InlineData(1403, 12, 30, 20, 03, 2025)]
+    [InlineData(1407, 01, 01, 20, 03, 2028)]
+    [InlineData(1407, 12, 29, 19, 03, 2029)]
+    [InlineData(1408, 01, 01, 20, 03, 2029)]
+    [InlineData(1408, 12, 30, 20, 03, 2030)]
+    [InlineData(1412, 12, 30, 20, 03, 2034)]
+    public void Test_ConvertToDateTime_ReturnCorrectDate(int year, int month, int day, int expectedDay, int expectedMonth, int expectedYear)
     {
         // Arrange
-        const int persianYear = 1403;
-        const int persianMonth = 01;
-        const int persianDay = 01;
+        //DateOnly? nullableDate = new DateOnly(year, month, day);
+        //DateOnly nonNullableDate = new DateOnly(year, month, day);
 
         // Act
-        var date = PersianDateTime.ToDateTime(persianYear, persianMonth, persianDay).Date;
-        var dateOnly = PersianDateTime.ToDateOnly(persianYear, persianMonth, persianDay);
+        var date = PersianDateTime.ToDateTime(year, month, day).Date;
+        var dateOnly = PersianDateTime.ToDateOnly(year, month, day);
 
         // Assert
-        Assert.Equal(new DateTime(2024, 03, 20).Date, date);
-        Assert.Equal(new DateOnly(2024, 03, 20), dateOnly);
+        Assert.Equal(new DateTime(expectedYear, expectedMonth, expectedDay).Date, date);
+        Assert.Equal(new DateOnly(expectedYear, expectedMonth, expectedDay), dateOnly);
     }
-
     [Fact]
     public void Test_IsGivenPersianYearIsLeap_ReturnCorrectDate()
     {

--- a/src/Persia.Net/Constants/CalendarConstants.cs
+++ b/src/Persia.Net/Constants/CalendarConstants.cs
@@ -3,11 +3,6 @@
 internal class CalendarConstants
 {
     /// <summary>
-    ///     The year of the start of the Common Era (Start of migration of Islam prophet), which is 622.
-    /// </summary>
-    internal const int CommonEra = 622;
-
-    /// <summary>
     ///     The Julian Day number of the start of the Gregorian calendar, which is October 15, 1582.
     /// </summary>
     internal const double GregorianEpoch = 1721425.5;
@@ -18,14 +13,9 @@ internal class CalendarConstants
     internal const double PersianEpoch = 1948320.5;
 
     /// <summary>
-    ///     The Julian Day number of the start of the Persian year 475, which is March 20, 1096.
+    /// Pivot value for the Gregorian reform adjustment (used in alpha calculation).
     /// </summary>
-    internal const double BasePersianEpoch = 2121445.5;
-
-    /// <summary>
-    ///      Base year reference for the Persian calendar.
-    /// </summary>
-    internal const int BasePersianYear = 475;
+    internal const double GregorianReformPivot = 1867216.25;
 
     /// <summary>
     ///     The Julian Day number of the start of the Islamic calendar, which is July 16, 622.
@@ -40,7 +30,7 @@ internal class CalendarConstants
     /// <summary>
     ///     The number of days in a non-leap year.
     /// </summary>
-    internal const double DaysInYear = 365;
+    internal const int DaysInYear = 365;
 
     /// <summary>
     ///     The number of years in the Gregorian calendar's leap year cycle.
@@ -66,11 +56,6 @@ internal class CalendarConstants
     ///     The number of years in a century.
     /// </summary>
     internal const double Century = 100;
-
-    /// <summary>
-    ///     The number of days in a Persian calendar cycle.
-    /// </summary>
-    internal const double CycleDays = 1029983;
 
     /// <summary>
     ///     The number of days at the end of a Persian calendar cycle.
@@ -103,19 +88,9 @@ internal class CalendarConstants
     internal const double CycleFactor = 1028522;
 
     /// <summary>
-    ///     An adjustment made to the epoch in Persian calendar calculations.
-    /// </summary>
-    internal const double EpochAdjustment = 474;
-
-    /// <summary>
     ///     The number of days in the first half of a Persian year.
     /// </summary>
-    internal const double DaysInHalfYear = 186;
-
-    /// <summary>
-    ///     The year before the epoch in the Persian calendar.
-    /// </summary>
-    internal const int YearBeforeEpoch = 474;
+    internal const int DaysInHalfYear = 186;
 
     /// <summary>
     ///     The number of months in the first half of a Persian year.
@@ -128,24 +103,9 @@ internal class CalendarConstants
     internal const int DaysInFirstHalfMonth = 31;
 
     /// <summary>
-    ///     A factor used in Persian calendar leap year calculations.
-    /// </summary>
-    internal const int LeapYearFactor = 682;
-
-    /// <summary>
-    ///     A value subtracted in Persian calendar leap year calculations.
-    /// </summary>
-    internal const int LeapYearSubtractor = 110;
-
-    /// <summary>
     ///     The number of days in the second half of a Persian month.
     /// </summary>
     internal const int DaysInSecondHalfMonth = 30;
-
-    /// <summary>
-    ///     The difference in days between the first half and second half of a Persian month.
-    /// </summary>
-    internal const int FirstHalfToSecondHalfDayDifference = 6;
 
     /// <summary>
     /// Represents the offset used to adjust the Julian day number to start from the middle of the day.
@@ -198,37 +158,37 @@ internal class CalendarConstants
     internal const int IslamicLeapYearMultiplier = 11;
 
     /// <summary>
-    /// The total number of days in a 400-year cycle of the Gregorian calendar.
+    /// Average number of days in a Gregorian “century” (100 × 365.2425).
     /// </summary>
-    internal const int DaysIn400Years = 146097;
+    internal const double DaysPerGregorianCentury = 36524.25;
 
     /// <summary>
-    /// The total number of days in a century (100 years) of the Gregorian calendar.
+    /// Offset to align the intermediate count so that March = month 1 in the algorithm.
     /// </summary>
-    internal const int DaysInCentury = 36524;
+    internal const int JulianConversionBaseOffset = 1524;
 
     /// <summary>
-    /// The total number of days in a 4-year cycle of the Gregorian calendar, including one leap year.
+    /// Companion offset for extracting the year from the day count.
     /// </summary>
-    internal const int DaysIn4YearCycle = 1461;
+    internal const double JulianYearOffset = 122.1;
 
     /// <summary>
-    /// The offset used in the calculation of the month from a Julian day number.
+    /// Average length of a Julian year, used when breaking out the year from days.
     /// </summary>
-    internal const int MonthCalculationOffset = 373;
+    internal const double JulianYearDays = 365.25;
 
     /// <summary>
-    /// The length of a complete grand cycle in the Persian calendar, consisting of 2820 years.
+    /// Factor for converting the remaining days into a month index.
     /// </summary>
-    internal const int PersianCalendarGrandCycle = 2820;
+    internal const double MonthExtractionFactor = 30.6001;
 
     /// <summary>
-    /// The number of years in the smaller cycles within the 2820-year grand cycle of the Persian calendar.
+    /// Year offset for dates in March–December when computing the final year.
     /// </summary>
-    internal const int YearsInSmallCycle = 120;
+    internal const int YearOffsetAfterFebruary = 4716;
 
     /// <summary>
-    /// The index of the last year in the smaller 120-year cycle of the Persian calendar.
+    /// Year offset for dates in January–February when computing the final year.
     /// </summary>
-    internal const int LastYearInSmallCycleIndex = 119;
+    internal const int YearOffsetBeforeMarch = 4715;
 }

--- a/src/Persia.Net/Persia.Net.csproj
+++ b/src/Persia.Net/Persia.Net.csproj
@@ -2,12 +2,12 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
-		<LangVersion>10</LangVersion>
+		<LangVersion>12</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
 		<PackageId>Persia.Net</PackageId>
-		<PackageVersion>4.2.0</PackageVersion>
+		<PackageVersion>4.3.0</PackageVersion>
 		<Authors>Majid Shahabfar</Authors>
 		<Description>Persia.Net is a versatile class library designed to seamlessly convert dates between Persian, Gregorian, and Islamic (Lunar Hijri) calendars.</Description>
 		<PackageProjectUrl>https://github.com/shahabfar/Persia.Net</PackageProjectUrl>
@@ -17,9 +17,9 @@
 		<AssemblyCompany>Shahabfar</AssemblyCompany>
 		<AssemblyProduct>Persia.Net</AssemblyProduct>
 		<AssemblyCopyright>Majid Shahabfar 2025</AssemblyCopyright>
-		<AssemblyVersion>4.2.0</AssemblyVersion>
-		<FileVersion>4.2.0</FileVersion>
-		<ProductVersion>4.2.0</ProductVersion>
+		<AssemblyVersion>4.3.0</AssemblyVersion>
+		<FileVersion>4.3.0</FileVersion>
+		<ProductVersion>4.3.0</ProductVersion>
 		<PackageIcon>persia-icon.png</PackageIcon>
 	</PropertyGroup>
 


### PR DESCRIPTION
- Added new test cases for the Persian calendar in `PersianDateOnlyTests.cs` for the years 2025, 2028, and 2029, while removing some outdated tests.
- Significantly refactored conversion methods in `Converter.cs` for improved accuracy and readability, particularly for leap year and month calculations.
- Updated project file `Persia.Net.csproj` to change the target language version to 12 and increment the package version to 4.3.0.